### PR TITLE
*fix* HC disconnect warning

### DIFF
--- a/A3-Antistasi/addHC.sqf
+++ b/A3-Antistasi/addHC.sqf
@@ -1,4 +1,6 @@
 _clientID = _this select 0;
+_hcuid = _this select 1;
 waitUntil {sleep 1;!(isNil "hcArray")};
 hcArray pushBackUnique _clientID;
+hc2Array pushBackUnique _hcuid;
 diag_log format ["Antistasi: HC added to the array: %1",hcArray];

--- a/A3-Antistasi/init.sqf
+++ b/A3-Antistasi/init.sqf
@@ -31,6 +31,7 @@ if (!isMultiPlayer) then
     [] execVM "initPetros.sqf";
 
     hcArray = [];
+    hc2Array = [];
     serverInitDone = true;
     diag_log "Antistasi SP. serverInitDone is true. Arsenal loaded";
     _nul = [] execVM "modBlacklist.sqf";

--- a/A3-Antistasi/initPlayerLocal.sqf
+++ b/A3-Antistasi/initPlayerLocal.sqf
@@ -22,7 +22,8 @@ if (isMultiplayer) then
 if (!hasInterface) exitWith
 	{
 	if (worldName == "Tanoa") then {call compile preprocessFileLineNumbers "roadsDB.sqf"} else {if (worldName == "Altis") then {call compile preprocessFileLineNumbers "roadsDBAltis.sqf"}};
-	[clientOwner] remoteExec ["A3A_fnc_addHC",2];
+	hcuid = getPlayerUID player;
+	[clientOwner,hcuid] remoteExec ["A3A_fnc_addHC",2];
 	};
 _isJip = _this select 1;
 if (isMultiplayer) then

--- a/A3-Antistasi/initServer.sqf
+++ b/A3-Antistasi/initServer.sqf
@@ -48,6 +48,7 @@ if (gameMode != 1) then
 [] execVM "initPetros.sqf";
 ["Initialize"] call BIS_fnc_dynamicGroups;//Exec on Server
 hcArray = [];
+hc2Array = [];
 waitUntil {(count playableUnits) > 0};
 waitUntil {({(isPlayer _x) and (!isNull _x) and (_x == _x)} count allUnits) == (count playableUnits)};//ya estamos todos
 _nul = [] execVM "modBlacklist.sqf";

--- a/A3-Antistasi/onPlayerDisconnect.sqf
+++ b/A3-Antistasi/onPlayerDisconnect.sqf
@@ -67,7 +67,7 @@ if (side group _unit == buenos) then
 		};
 	//if ([_unit] call A3A_fnc_isMember) then {playerHasBeenPvP pushBack [getPlayerUID _unit,time]};
 	};
-if ((owner _unit) in hcArray) then
+if (_uid in hc2Array) then
 	{
 	//["hcDown",true,true,true,true] remoteExec ["BIS_fnc_endMission"]
 	_owner = owner _unit;


### PR DESCRIPTION
After a HC disconnected, warning message was not executed. Instead of checking playerID of the disconnected HC against the array that holds all HC playerIDs, server playerID (2) was always used.

It is impossible to get the playerID of a disconnecting client after the client disconnected.

This fix uses players uid.